### PR TITLE
Harden the nightly backup workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,27 +1,35 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI
+name: Nightly backup
 
 on:
   schedule:
-    - cron:  '0 4 * * *'
+    - cron: '0 4 * * *'
+  # Allow manual runs from the Actions tab (handy for testing / on-demand backups).
+  workflow_dispatch: {}
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "bxuild"
   backup:
     name: Perform Backup
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2.2.0
+      # No checkout: the backup runs against the remote Upsun project by ID and
+      # never touches the repo, so there's nothing to check out. (Dropping it
+      # also removes the deprecated actions/checkout Node-runtime warning.)
       - name: Install Upsun CLI
         run: |
           curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | VENDOR=upsun bash
-          echo "/home/runner/.global/bin" >> $GITHUB_PATH
-      - name: Run backup
-        run: upsun backup:create -W -y -p ${{secrets.UPSUN_PROJECT}} main
+          echo "/home/runner/.global/bin" >> "$GITHUB_PATH"
+      - name: Create backup (retrying transient API errors)
+        run: |
+          for attempt in 1 2 3; do
+            if upsun backup:create -W -y -p "$UPSUN_PROJECT" main; then
+              exit 0
+            fi
+            echo "::warning::Backup attempt ${attempt} failed; retrying in 30s..."
+            sleep 30
+          done
+          echo "::error::All backup attempts failed."
+          exit 1
         env:
-          UPSUN_CLI_TOKEN: ${{secrets.UPSUN_CLI_TOKEN}}
+          UPSUN_CLI_TOKEN: ${{ secrets.UPSUN_CLI_TOKEN }}
+          UPSUN_PROJECT: ${{ secrets.UPSUN_PROJECT }}


### PR DESCRIPTION
## Diagnosis
The nightly Upsun backup (`.github/workflows/main.yml`) isn't chronically broken — **19 of the last 20 runs succeeded**. The one failure (2026-07-21) was a transient `503 backend read error` from Upsun's API, which recovered on its own. What made it *look* broken is the persistent yellow annotation on every run: `actions/checkout@v2.2.0` targets a deprecated Node runtime.

## Changes
- **Remove the unused `actions/checkout@v2.2.0` step.** The backup runs against the remote project by ID and never reads the repo, so checkout did nothing — removing it eliminates the deprecation warning at the source instead of just bumping to v4.
- **Retry the backup 3× with a 30s backoff**, so a transient API 503 no longer fails the night.
- **Add `workflow_dispatch`** (manual runs) and a **10-minute timeout**; rename the workflow `CI` → `Nightly backup`.

## Notes
- Scheduled workflows run from the version on the **default branch**, so this takes effect once merged to `main`.
- After merge I can trigger a manual run (`gh workflow run "Nightly backup"`) to confirm it's green end-to-end.
- Standing observation (not addressed here): the site is now a **static build with no database or mounts**, so this environment backup is largely vestigial — git is effectively the backup. You chose to keep it (Option B); flagging the context in case you later decide it's not worth the minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)